### PR TITLE
Plugin tests are a subset of integration and system tests

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -81,8 +81,6 @@ then
         then
             echo "Executing tests in test suite IntegrationTests"
             travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite IntegrationTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
-            echo "Executing tests in test suite PluginTests"
-            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite PluginTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
         else
             travis_wait ./../../console tests:run --options="--colors" || exit_code=$?
         fi


### PR DESCRIPTION
Therefore it is not needed to execute it again. This explains why MySQLi test takes 20min longer than the integration tests for PDO