### PR TITLE
Make using travis' trusty distribution the default, and remove all re…

### DIFF
--- a/generator/GenerateTravisYmlFile.php
+++ b/generator/GenerateTravisYmlFile.php
@@ -46,7 +46,7 @@ class GenerateTravisYmlFile extends Command
             ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.")
             ->addOption('force-php-tests', null, InputOption::VALUE_NONE, "Forces the presence of the PHP tests jobs for plugin builds.")
             ->addOption('force-ui-tests', null, InputOption::VALUE_NONE, "Forces the presence of the UI tests jobs for plugin builds.")
-            ->addOption('dist-trusty', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' trusty distribution.")
+            ->addOption('dist-trusty', null, InputOption::VALUE_NONE, "Just for backwards compatibility, using travis' trusty distribution is the default now.")
             ->addOption('sudo-false', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' container environment.");
     }
 

--- a/generator/Generator.php
+++ b/generator/Generator.php
@@ -147,10 +147,6 @@ abstract class Generator
 
         $this->setExtraEnvironmentVariables();
 
-        if (!empty($this->options['dist-trusty'])) {
-            $this->view->useTravisTrustyDistribution();
-        }
-
         if (!empty($this->options['sudo-false'])) {
             $this->view->useTravisContainerEnvironment();
         }

--- a/generator/TravisYmlView.php
+++ b/generator/TravisYmlView.php
@@ -254,11 +254,6 @@ class TravisYmlView
         $this->variables['useTravisContainerEnvironment'] = true;
     }
 
-    public function useTravisTrustyDistribution()
-    {
-        $this->variables['useTravisTrustyDistribution'] = true;
-    }
-
     public function render()
     {
         return $this->twig->render('travis.yml.twig', $this->variables);

--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -43,11 +43,9 @@ addons:
 {% if partials['addons.apt.packages']|default is not empty %}      {{ partials['addons.apt.packages']|indent(6)|raw }}
 {% endif %}
 
-{% if generationMode == 'core' or useTravisTrustyDistribution|default %}
 git:
   lfs_skip_smudge: true
 
-{% endif %}
 # Separate different test suites
 {% if existingEnv|default is empty -%}
 env:
@@ -90,8 +88,7 @@ matrix:
   {{ existingMatrix|trim|raw }}
 {% endif %}
 
-dist: {% if generationMode == 'core' or useTravisTrustyDistribution|default %}trusty{% else %}precise{% endif %}
-
+dist: trusty
 {% if generationMode == 'plugin' %}
 
 sudo: {% if useTravisContainerEnvironment|default %}false{% else %}required{% endif %}

--- a/generator/tests/Integration/TravisYmlViewTest.php
+++ b/generator/tests/Integration/TravisYmlViewTest.php
@@ -33,7 +33,6 @@ class TravisYmlViewTest extends PHPUnit_Framework_TestCase
             array('name' => "PluginTests", 'vars' => "MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=latest_stable")
         ));
         $view->useTravisContainerEnvironment();
-        $view->useTravisTrustyDistribution();
         $output = $view->render();
 
         $yaml = Spyc::YAMLLoadString($output);


### PR DESCRIPTION
…lated case switching.

This will break all plugin builds that still did not use the --dist-trusty switch for generating their .travis.yml.
However, those were broken anyway by travis' precise distribution not being able to install python2.6.

This fixes
https://github.com/matomo-org/matomo/issues/13244
in a quite radical way.