### PR TITLE
Use new log file name

### DIFF
--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -200,7 +200,7 @@ after_script:
   # output contents of files w/ debugging info to screen
   - cat $PIWIK_ROOT_DIR/tests/travis/error.log
   - cat $PIWIK_ROOT_DIR/tmp/php-fpm.log
-  - cat $PIWIK_ROOT_DIR/tmp/logs/piwik.log
+  - cat $PIWIK_ROOT_DIR/tmp/logs/matomo.log
   - cat $PIWIK_ROOT_DIR/config/config.ini.php
 
   # upload test artifacts (for debugging travis failures)


### PR DESCRIPTION
When that one gets merged we need to update all `.travis.yml` files in all repos. Would do that directly on the master branches once this one is approved

fixes matomo-org/matomo#14394