### PR TITLE
Ensure Matomo is checked out correctly for plugin builds

### DIFF
--- a/autoupdate_travis_yml.sh
+++ b/autoupdate_travis_yml.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script is executed before the plugin files are copied to the plugins directory and is executed on
-# the Piwik master branch.
+# the Matomo master branch.
 
 if [ "$REPO_ROOT_DIR" == "" ]; then
     if [ "$PLUGIN_NAME" != "" ]; then

--- a/generator/templates/travis.yml.twig
+++ b/generator/templates/travis.yml.twig
@@ -55,11 +55,11 @@ env:
 {% endif %}{% if generationMode == 'core' %}
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR
 {% else %}
-    - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    # this variable controls the version of Piwik your tests will run against.
+    - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/matomo
+    # this variable controls the version of Matomo your tests will run against.
     # by default it will run against the maximum support version read from plugin.json
     # (PIWIK_TEST_TARGET=maximum_supported_piwik).
-    # You can also specify a specific Piwik version
+    # You can also specify a specific Matomo version
     # (PIWIK_TEST_TARGET=2.16.0-b1).
     - PIWIK_TEST_TARGET=maximum_supported_piwik
 {% endif %}
@@ -123,14 +123,14 @@ install:
   - cp .travis.yml $PLUGIN_NAME
 {% endif %}
 {% if generationMode != 'core' %}
-  # checkout piwik in the current directory
-  - git clone -q https://github.com/piwik/piwik.git piwik
-  - cd piwik
+  # checkout matomo in the current directory
+  - git clone -q https://github.com/matomo-org/matomo.git matomo
+  - cd matomo
   - git fetch -q --all
   - git submodule update
 
   # make sure travis-scripts repo is latest for initial travis setup
-  - '[ -d ./tests/travis/.git ] || sh -c "rm -rf ./tests/travis && git clone https://github.com/piwik/travis-scripts.git ./tests/travis"'
+  - '[ -d ./tests/travis/.git ] || sh -c "rm -rf ./tests/travis && git clone https://github.com/matomo-org/travis-scripts.git ./tests/travis"'
   - cd ./tests/travis ; git checkout master ; cd ../..
 {% else %}
   - git fetch -q

--- a/generator/tests/resources/test.travis.yml
+++ b/generator/tests/resources/test.travis.yml
@@ -14,13 +14,13 @@ env:
 script: ./travis.sh
 
 install:
-  - TEST_PIWIK_VERSION=$(wget builds.piwik.org/LATEST -q -O -)
+  - TEST_PIWIK_VERSION=$(wget builds.matomo.org/LATEST -q -O -)
   - TEST_PIWIK_VERSION=`echo $TEST_PIWIK_VERSION | tr -d ' ' | tr -d '\n'`
   - mkdir ExamplePlugin
   - cp -R !(ExamplePlugin) ExamplePlugin
   - cp -R .git/ ExamplePlugin/
-  - git clone https://github.com/piwik/piwik.git piwik
-  - cd piwik
+  - git clone https://github.com/matomo-org/matomo.git matomo
+  - cd matomo
   - git checkout "$TEST_PIWIK_VERSION"
   - git submodule init
   - git submodule update || true
@@ -28,16 +28,16 @@ install:
   - composer install
   - rm -rf plugins/ExamplePlugin
   - cd ../
-  - mv ExamplePlugin piwik/plugins
+  - mv ExamplePlugin matomo/plugins
 
 before_script:
-  - cd piwik
+  - cd matomo
   - uname -a
   - date
   - mysql -e 'create database piwik_tests;'
   - ./tests/travis/prepare.sh
   - ./tests/travis/setup_webserver.sh
-  - wget https://raw.github.com/piwik/piwik-tests-plugins/master/activateplugin.php
+  - wget https://raw.github.com/matomo-org/piwik-tests-plugins/master/activateplugin.php
   - php activateplugin.php ExamplePlugin
   - cd tests/PHPUnit
 


### PR DESCRIPTION
Build for plugins are failing due to the woff2 changes. This will fix it, but requires updates for all travis.yml files