### PR TITLE
enable load data infile for mysqli &switch test units for faster builds

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -76,3 +76,6 @@ phpenv config-add ./tmp/redis.ini
 
 # increase memory limit
 echo "memory_limit = 256M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
+# enable local infile for mysqli
+echo "mysqli.allow_local_infile = On" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/travis.sh
+++ b/travis.sh
@@ -73,14 +73,14 @@ then
 
         if [ "$ALLTEST_EXTRA_OPTIONS" = "--run-first-half-only" ]
         then
-            echo "Executing tests in test suite SystemTests for Core"
-            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite SystemTestsCore --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
+            echo "Executing tests in test suite UnitTests"
+            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite UnitTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
             echo "Executing tests in test suite SystemTests for Plugins"
             travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite SystemTestsPlugins --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
         elif [ "$ALLTEST_EXTRA_OPTIONS" = "--run-second-half-only" ]
         then
-            echo "Executing tests in test suite UnitTests"
-            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite UnitTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
+            echo "Executing tests in test suite SystemTests for Core"
+            travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite SystemTestsCore --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
             echo "Executing tests in test suite IntegrationTests"
             travis_wait ./../../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --testsuite IntegrationTests --colors $PHPUNIT_EXTRA_OPTIONS || exit_code=$?
         else


### PR DESCRIPTION
Load data infile test on mysql failed as `mysqli.allow_local_infile` wasn't enabled in PHP setting.

And as the AllTests Unit have quite different run times 27m <> 46m, I've switched the units ran in both, so both should take around 35 mins. Hopes that improves the overall build run time.