### PR TITLE
Delete test folders of dependent plugin

### DIFF
--- a/checkout_dependent_plugins.sh
+++ b/checkout_dependent_plugins.sh
@@ -18,6 +18,13 @@ else
         else
             git clone --depth=1 "https://$GITHUB_USER_TOKEN:@github.com/$pluginSlug" "plugins/$dependentPluginName" 2>&1 | sed "s/$GITHUB_USER_TOKEN/GITHUB_USER_TOKEN/"
         fi
+        
+        rm -rf "plugins/$dependentPluginName/tests/Integration"
+        rm -rf "plugins/$dependentPluginName/Test/Integration"
+        rm -rf "plugins/$dependentPluginName/tests/Unit"
+        rm -rf "plugins/$dependentPluginName/Test/Unit"
+        rm -rf "plugins/$dependentPluginName/tests/System"
+        rm -rf "plugins/$dependentPluginName/Test/System"
     done
 
     echo "Plugin directory:"


### PR DESCRIPTION
Trying to make cloud tests 4.x compatible and run them on travis. However, problematic are the dependent plugins. eg it had `DEPENDENT_PLUGINS="innocraft/plugin-ProxySite innocraft/plugin-Account2`. However, ProxySite is again dependent on Heatmaps, Media Analytics, etc and I end up needing to add all possible dependencies in the cloud plugin. I guess generally if they were all compatible with 4.X it was less of a problem. However, as soon as some dependent plugin is having an error in the tests then it causes errors in the tests of the actual plugin etc.

```
​PHP Fatal error:  Uncaught Error: Class 'Piwik\Plugins\HeatmapSessionRecording\tests\Fixtures\HeatmapSessionFixture' not found in matomo/plugins/ProxySite/tests/System/ProxyingTest.php:207
``` 

Generally, I have bit mixed feeling. In some way it is good that all dependencies are being loaded and validated etc. On the other side it's a bit of a pain. Not sure if we should merge or not but thought I create the PR and see some feedback @sgiehl @diosmosis 

I'd keep the fixture directories in the tests folder just in case some plugin was to use other test fixtures but I suppose that wouldn't really be the case.