### PR TITLE
Replace Piwik with Matomo

### DIFF
--- a/check_plugin_compatible_with_piwik.php
+++ b/check_plugin_compatible_with_piwik.php
@@ -7,7 +7,7 @@
  */
 
 require_once __DIR__ . '/../../core/Version.php';
-require_once __DIR__ . '/piwik_version_parser.php';
+require_once __DIR__ . '/matomo_version_parser.php';
 
 $pluginName = $argv[1];
 
@@ -19,7 +19,7 @@ $pluginJsonPath = __DIR__ . "/../../../$pluginName/plugin.json";
 $pluginJsonContents = file_get_contents($pluginJsonPath);
 $pluginJsonContents = json_decode($pluginJsonContents, true);
 
-$requiredVersions = getRequiredPiwikVersions($pluginJsonContents);
+$requiredVersions = getRequiredMatomoVersions($pluginJsonContents);
 
 foreach ($requiredVersions as $requiredVersion) {
     $comparison = $requiredVersion['comparison'];

--- a/checkout_test_against_branch.sh
+++ b/checkout_test_against_branch.sh
@@ -12,7 +12,7 @@ if [ "$TEST_AGAINST_PIWIK_BRANCH" == "" ]; then
         #echo "Testing against 'latest_stable' is no longer supported, please test against 'minimum_required_piwik'."
         #exit 1
     elif [[ "$TEST_AGAINST_CORE" == "minimum_required_piwik" && "$PLUGIN_NAME" != "" ]]; then # test against the minimum required Piwik in the plugin.json file
-        export TEST_AGAINST_PIWIK_BRANCH=$(php "$SCRIPT_DIR/get_required_piwik_version.php" $PLUGIN_NAME)
+        export TEST_AGAINST_PIWIK_BRANCH=$(php "$SCRIPT_DIR/get_required_matomo_version.php" $PLUGIN_NAME)
 
         if ! git rev-parse "$TEST_AGAINST_PIWIK_BRANCH" >/dev/null 2>&1
         then
@@ -21,8 +21,8 @@ if [ "$TEST_AGAINST_PIWIK_BRANCH" == "" ]; then
             export TEST_AGAINST_PIWIK_BRANCH=4.x-dev
         fi
     fi
-elif [[ "$TEST_AGAINST_PIWIK_BRANCH" == "maximum_supported_piwik" && "$PLUGIN_NAME" != "" ]]; then # test against the maximum supported Piwik in the plugin.json file
-    export TEST_AGAINST_PIWIK_BRANCH=$(php "$SCRIPT_DIR/get_required_piwik_version.php" $PLUGIN_NAME "max")
+elif [[ "$TEST_AGAINST_PIWIK_BRANCH" == "maximum_supported_piwik" && "$PLUGIN_NAME" != "" ]]; then # test against the maximum supported Matomo in the plugin.json file
+    export TEST_AGAINST_PIWIK_BRANCH=$(php "$SCRIPT_DIR/get_required_matomo_version.php" $PLUGIN_NAME "max")
 
     if ! git rev-parse "$TEST_AGAINST_PIWIK_BRANCH" >/dev/null 2>&1
     then

--- a/configure_git.sh
+++ b/configure_git.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if [ "$TRAVIS_COMMITTER_EMAIL" == "" ]; then
-    TRAVIS_COMMITTER_EMAIL="hello@piwik.org"
+    TRAVIS_COMMITTER_EMAIL="hello@matomo.org"
 fi
 
 if [ "$TRAVIS_COMMITTER_NAME" == "" ]; then
-    TRAVIS_COMMITTER_NAME="Piwik Automation"
+    TRAVIS_COMMITTER_NAME="Matomo Automation"
 fi
 
 echo "Configuring git [email = $TRAVIS_COMMITTER_EMAIL, user = $TRAVIS_COMMITTER_NAME]..."

--- a/generator/GenerateTravisYmlFile.php
+++ b/generator/GenerateTravisYmlFile.php
@@ -18,8 +18,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Exception;
 
 /**
- * Command to generate an self-updating .travis.yml file either for Piwik Core or
- * an individual Piwik plugin.
+ * Command to generate an self-updating .travis.yml file either for Matomo Core or
+ * an individual Matomo plugin.
  */
 class GenerateTravisYmlFile extends Command
 {
@@ -30,12 +30,12 @@ class GenerateTravisYmlFile extends Command
         $this->setName(self::COMMAND_NAME)
             ->setDescription('Generates a .travis.yml file for a plugin. The file can be auto-updating based on the parameters supplied.')
             ->addOption('plugin', null, InputOption::VALUE_REQUIRED, 'The plugin for whom a .travis.yml file should be generated.')
-            ->addOption('core', null, InputOption::VALUE_NONE, 'Supplied when generating the .travis.yml file for Piwik core.'
+            ->addOption('core', null, InputOption::VALUE_NONE, 'Supplied when generating the .travis.yml file for Matomo core.'
                 . ' Should only be used by core developers.')
             ->addOption('piwik-tests-plugins', null, InputOption::VALUE_REQUIRED, 'Supplied when generating the .travis.yml file for the '
                 . 'piwik-tests-plugins repository. Should only be used by core developers.')
             ->addOption('artifacts-pass', null, InputOption::VALUE_REQUIRED,
-                "Password to the Piwik build artifacts server. Will be encrypted in the .travis.yml file.")
+                "Password to the Matomo build artifacts server. Will be encrypted in the .travis.yml file.")
             ->addOption('github-token', null, InputOption::VALUE_REQUIRED,
                 "Github token of a user w/ push access to this repository. Used to auto-commit updates to the "
                 . ".travis.yml file and checkout dependencies. Will be encrypted in the .travis.yml file.\n\n"

--- a/generator/composer.json
+++ b/generator/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "piwik/travis-yml-generator",
+    "name": "matomo/travis-yml-generator",
     "require": {
         "twig/twig": "^1.18",
         "symfony/console": "~2.6"
@@ -11,8 +11,8 @@
     },
     "authors": [
         {
-            "name": "Piwik",
-            "email": "hello@piwik.org"
+            "name": "Matomo",
+            "email": "hello@matomo.org"
         }
     ]
 }

--- a/get_required_matomo_version.php
+++ b/get_required_matomo_version.php
@@ -11,7 +11,7 @@ $returnMaxVersion = !empty($argv[2]) && $argv[2] === 'max';
 
 // tiny script to get plugin version from plugin.json from a bash script
 require_once __DIR__ . '/../../core/Version.php';
-require_once __DIR__ . '/piwik_version_parser.php';
+require_once __DIR__ . '/matomo_version_parser.php';
 
 // at this point in travis the plugin to test against is not in the piwik directory. we could move it to piwik
 // beforehand, but for plugins that are also stored as submodules, this would erase the plugin or fail when git
@@ -20,13 +20,13 @@ $pluginJsonPath     = __DIR__ . "/../../../$pluginName/plugin.json";
 $pluginJsonContents = file_get_contents($pluginJsonPath);
 $pluginJsonContents = json_decode($pluginJsonContents, true);
 
-$requiredVersions = getRequiredPiwikVersions($pluginJsonContents);
+$requiredVersions = getRequiredMatomoVersions($pluginJsonContents);
 
 if ($returnMaxVersion) {
     $versionToReturn = getMaxVersion($requiredVersions);
 
     if (empty($versionToReturn)) {
-        $versionToReturn = trim(file_get_contents('http://api.piwik.org/LATEST_BETA'));
+        $versionToReturn = trim(file_get_contents('https://api.matomo.org/LATEST_BETA'));
     }
 } else {
     $versionToReturn = getMinVersion($requiredVersions);

--- a/latest_beta_build_explain.txt
+++ b/latest_beta_build_explain.txt
@@ -8,9 +8,9 @@ supported version in plugin.json is specified.
 If you want to run this build against a fixed Matomo version, specifiy either a
 maximum supported Matomo version in plugin.json like this:
 
-'require": { "piwik": ">=2.15.0-rc1,<=2.15.0-rc1" },'
+'require": { "matomo": ">=2.15.0-rc1,<=2.15.0-rc1" },'
 
-or specify a specifc "PIWIK_TEST_TARGET" Matomo version in your ".travis.yml".
+or specify a specific "PIWIK_TEST_TARGET" Matomo version in your ".travis.yml".
 
 
 Why is this important?
@@ -31,7 +31,7 @@ What to do when this build fails?
 * Make your plugin compatible with the latest Matomo version
 * If you cannot make your plugin compatible with the latest Matomo version,
   specify a maximum supported Matomo version in your plugin.json file like this:
-  '"require": { "piwik": ">=2.15.0-rc1,<=2.15.0-rc1" },'
+  '"require": { "matomo": ">=2.15.0-rc1,<=2.15.0-rc1" },'
 * If you need any help with this contact the Matomo core team
 
 ******************************************************************************

--- a/matomo_version_parser.php
+++ b/matomo_version_parser.php
@@ -9,14 +9,16 @@
 // tiny script to get plugin version from plugin.json from a bash script
 require_once __DIR__ . '/../../core/Version.php';
 
-function getRequiredPiwikVersions($pluginJsonContents)
+function getRequiredMatomoVersions($pluginJsonContents)
 {
-    $requiredPiwikVersion = '';
+    $requiredMatomoVersion = '';
     if (isset($pluginJsonContents["require"]["piwik"])) {
-        $requiredPiwikVersion = (string) $pluginJsonContents["require"]["piwik"];
+        $requiredMatomoVersion = (string) $pluginJsonContents["require"]["piwik"];
+    } else if (isset($pluginJsonContents["require"]["matomo"])) {
+        $requiredMatomoVersion = (string) $pluginJsonContents["require"]["matomo"];
     }
 
-    $requiredVersions = explode(',', $requiredPiwikVersion);
+    $requiredVersions = explode(',', $requiredMatomoVersion);
 
     $versions = array();
     foreach ($requiredVersions as $required) {
@@ -70,13 +72,13 @@ function getMaxVersion(array $requiredVersions)
         $version    = $required['version'];
 
         if ($comparison == '<' && $version == '3.0.0-b1') {
-            $maxVersion = trim(file_get_contents('http://api.piwik.org/1.0/getLatestVersion/?release_channel=latest_2x_beta'));
+            $maxVersion = trim(file_get_contents('https://api.matomo.org/1.0/getLatestVersion/?release_channel=latest_2x_beta'));
             continue;
         } elseif ($comparison == '<' && $version == '4.0.0-b1') {
-            $maxVersion = trim(file_get_contents('http://api.piwik.org/1.0/getLatestVersion/?release_channel=latest_3x_beta'));
+            $maxVersion = trim(file_get_contents('https://api.matomo.org/1.0/getLatestVersion/?release_channel=latest_3x_beta'));
             continue;
         } elseif ($comparison == '<' && $version == '5.0.0-b1') {
-            $maxVersion = trim(file_get_contents('http://api.piwik.org/1.0/getLatestVersion/?release_channel=latest_4x_beta'));
+            $maxVersion = trim(file_get_contents('https://api.matomo.org/1.0/getLatestVersion/?release_channel=latest_4x_beta'));
             continue;
         }
 

--- a/travis.sh
+++ b/travis.sh
@@ -50,7 +50,7 @@ then
         echo -n "./console tests:sync-ui-screenshots $TRAVIS_BUILD_NUMBER"
         if [ -n "$PLUGIN_NAME" ]
         then
-            echo -n " --repository=piwik/plugin-$PLUGIN_NAME"
+            echo -n " --repository=matomo-org/plugin-$PLUGIN_NAME"
 
             if [ "$PROTECTED_ARTIFACTS" = "1" ];
             then
@@ -64,9 +64,9 @@ then
         if [ -n "$PLUGIN_NAME" ]
         then
             # HACK: this is a hack to get UI test jobs to run. the --extra-options option was added for 2.15.1, but
-            #       older Piwik's will end up w/ a tests:run-ui command that doesn't support it.
-            # a better fix would be to decouple the piwik testing framework from piwik in a way that allowed us to
-            # change code for all versions of Piwik as well as selectively for individual Piwik versions.
+            #       older Matomo's will end up w/ a tests:run-ui command that doesn't support it.
+            # a better fix would be to decouple the Matomo testing framework from Matomo in a way that allowed us to
+            # change code for all versions of Matomo as well as selectively for individual Matomo versions.
             git checkout 4.x-dev ../../plugins/TestRunner/Commands/TestsRunUI.php
 
             ./../../console tests:run-ui --assume-artifacts --persist-fixture-data --plugin=$PLUGIN_NAME --extra-options="$UITEST_EXTRA_OPTIONS --screenshot-repo=$TRAVIS_REPO_SLUG"

--- a/travis.sh
+++ b/travis.sh
@@ -50,7 +50,7 @@ then
         echo -n "./console tests:sync-ui-screenshots $TRAVIS_BUILD_NUMBER"
         if [ -n "$PLUGIN_NAME" ]
         then
-            echo -n " --repository=matomo-org/plugin-$PLUGIN_NAME"
+            echo -n " --repository=$TRAVIS_REPO_SLUG"
 
             if [ "$PROTECTED_ARTIFACTS" = "1" ];
             then


### PR DESCRIPTION
Note: There are quite some more occurrences of `Piwik`, but replacing them would require to regenerate all `.travis.yml` files in all repos. Decided not to do that by now, as that might take too much time. Guess we can think about replacing the rest, when we need to update the travis files due another required change maybe.

fixes #71