### PR TITLE
Revert "Install npm dependencies for AngularJS tests too."

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -19,7 +19,7 @@ then
 fi
 
 # Install fonts for UI tests
-if [ "$TEST_SUITE" = "UITests" ] || [ "$TEST_SUITE" = "JavascriptTests" ] || [ "$TEST_SUITE" = "AngularJSTests" ];
+if [ "$TEST_SUITE" = "UITests" ] || [ "$TEST_SUITE" = "JavascriptTests" ];
 then
     mkdir $HOME/.fonts
     cp ./tests/travis/fonts/* $HOME/.fonts


### PR DESCRIPTION
Reverts matomo-org/travis-scripts#73

FYI @tsteur this installs the screenshot-testing folder dependencies, so didn't do what I expected.