### PR TITLE
Adjust ImageMagick policy to ensure all screenshot tests can be compared

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -36,6 +36,13 @@ then
     npm install
     node --version
     cd $PIWIK_ROOT_DIR
+
+    # adjust ImageMagick policy to ensure all screenshot tests can be compared
+    sudo sed -i -E 's/name="memory" value="[^"]+"/name="memory" value="2GiB"/g' /etc/ImageMagick-6/policy.xml
+    sudo sed -i -E 's/name="width" value="[^"]+"/name="width" value="64KP"/g' /etc/ImageMagick-6/policy.xml
+    sudo sed -i -E 's/name="height" value="[^"]+"/name="height" value="64KP"/g' /etc/ImageMagick-6/policy.xml
+    sudo sed -i -E 's/name="area" value="[^"]+"/name="area" value="1GiB"/g' /etc/ImageMagick-6/policy.xml
+    sudo sed -i -E 's/name="disk" value="[^"]+"/name="area" value="4GiB"/g' /etc/ImageMagick-6/policy.xml
 fi
 
 # Copy Piwik configuration


### PR DESCRIPTION
Default policy for imagemagick on ubuntu bionic only covers dimensions that are too small for some of our test images.
Increasing the policy values seems to fix the issues in https://github.com/matomo-org/matomo/pull/18111